### PR TITLE
fixed error handler bug

### DIFF
--- a/R/segmented.glm.R
+++ b/R/segmented.glm.R
@@ -207,7 +207,7 @@ function(obj, seg.Z, psi, npsi, fixed.psi=NULL, control = seg.control(), model =
       names(fixed.psi)<-all.vars(seg.Z)
     }
     if(is.list(fixed.psi)) {
-      if(!(names(fixed.psi) %in% all.vars(seg.Z))) stop("names(fixed.psi) is not a subset of variables in 'seg.Z' ")
+      if(!all(names(fixed.psi) %in% all.vars(seg.Z))) stop("names(fixed.psi) is not a subset of variables in 'seg.Z' ")
     } else {
       stop(" 'fixed.psi' has to be a named list ")
       } 

--- a/R/segmented.lm.R
+++ b/R/segmented.lm.R
@@ -232,7 +232,7 @@ if(!is.null(nomiNO)) mfExt$formula<-update.formula(mfExt$formula,paste(".~.-", p
       names(fixed.psi)<-all.vars(seg.Z)
     }
     if(is.list(fixed.psi)) {
-      if(!(names(fixed.psi) %in% all.vars(seg.Z))) stop("names(fixed.psi) is not a subset of variables in 'seg.Z' ")
+      if(!all(names(fixed.psi) %in% all.vars(seg.Z))) stop("names(fixed.psi) is not a subset of variables in 'seg.Z' ")
     } else {
       stop(" 'fixed.psi' has to be a named list ")
       } 


### PR DESCRIPTION
@gaborcsardi this tiny patch resolves an error that occurs when `fixed.psi` has length > 1 under R 4.2.0 and higher. This used to produce a warning, but now it produces an error ([changelog here](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html)). 